### PR TITLE
Scopes no longer own their allocations or child scopes.

### DIFF
--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -1,9 +1,105 @@
+use std::collections::hash_map::{Entry, HashMap};
+use std::collections::hash_set::HashSet;
+use std::rc::Rc;
+use std::cell::RefCell;
+use uuid::Uuid;
+
+use js_types::js_type::{JsVar, JsType, JsPtrEnum};
+
 pub mod scope;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use js_types::js_type::{JsVar, JsType};
-    use js_types::js_obj::JsObjStruct;
-    use js_types::js_str::JsStrStruct;
+pub type Alloc<T> = Rc<RefCell<T>>;
+
+pub struct AllocBox {
+    black_set: HashMap<Uuid, Alloc<JsPtrEnum>>,
+    grey_set: HashMap<Uuid, Alloc<JsPtrEnum>>,
+    white_set: HashMap<Uuid, Alloc<JsPtrEnum>>,
+}
+
+impl AllocBox {
+    pub fn new() -> AllocBox {
+        AllocBox {
+            black_set: HashMap::new(),
+            grey_set: HashMap::new(),
+            white_set: HashMap::new(),
+        }
+    }
+
+    pub fn alloc(&mut self, uuid: Uuid, ptr: JsPtrEnum) -> Uuid {
+        self.white_set.insert(uuid, Rc::new(RefCell::new(ptr)));
+        uuid
+    }
+
+    pub fn dealloc(&mut self, uuid: &Uuid) -> bool {
+        if let Some(_) = self.white_set.remove(uuid) { true } else { false }
+    }
+
+    pub fn mark_roots(&mut self, marks: HashSet<Uuid>) {
+        for mark in marks {
+            // FIXME? Could a root be grey already?
+            if let Some(ptr) = self.white_set.remove(&mark) {
+                // Get all child references
+                let child_ids = AllocBox::get_var_children(&ptr);
+                // Mark current ref as black
+                self.black_set.insert(mark, ptr);
+                // Mark child references as grey
+                self.grey_children(child_ids);
+            }
+        }
+    }
+
+    pub fn mark_vars(&mut self) {
+        // Mark any grey object as black, and mark all white objs it refs as grey
+        let mut new_grey_set = HashMap::new();
+        for (uuid, var) in self.grey_set.drain() {
+            let child_ids = AllocBox::get_var_children(&var);
+            self.black_set.insert(uuid, var);
+            for child_id in child_ids {
+                if let Some(var) = self.white_set.remove(&child_id) {
+                    new_grey_set.insert(child_id, var);
+                }
+            }
+        }
+        self.grey_set = new_grey_set;
+    }
+
+    pub fn sweep_vars(&mut self) {
+        self.white_set = HashMap::new();
+    }
+
+    pub fn find_id(&self, uuid: &Uuid) -> Option<&Alloc<JsPtrEnum>> {
+        self.white_set.get(uuid).or_else(||
+            self.grey_set.get(uuid).or_else(||
+                self.black_set.get(uuid)))
+    }
+
+    pub fn update_var(&mut self, uuid: Uuid, ptr: JsPtrEnum) -> bool {
+        if let Entry::Occupied(mut view) = self.find_id_mut(&uuid) {
+            let inner = view.get_mut();
+            *inner.borrow_mut() = ptr;
+            true
+        } else { false }
+    }
+
+    fn grey_children(&mut self, child_ids: HashSet<Uuid>) {
+        for child_id in child_ids.iter() {
+            if let Some(var) = self.white_set.remove(child_id) {
+                self.grey_set.insert(*child_id, var);
+            }
+        }
+    }
+
+    fn get_var_children(ptr: &Alloc<JsPtrEnum>) -> HashSet<Uuid> {
+        if let JsPtrEnum::JsObj(ref obj) = *ptr.borrow() {
+            obj.get_children()
+        } else { HashSet::new() }
+    }
+
+    fn find_id_mut(&mut self, uuid: &Uuid) -> Entry<Uuid, Alloc<JsPtrEnum>> {
+        if let e @ Entry::Occupied(_) = self.white_set.entry(*uuid) {
+            e
+        } else if let e @ Entry::Occupied(_) = self.grey_set.entry(*uuid) {
+            e
+        } else { self.black_set.entry(*uuid) }
+    }
 }

--- a/src/js_types/js_obj.rs
+++ b/src/js_types/js_obj.rs
@@ -4,17 +4,17 @@ use std::string::String;
 use std::vec::Vec;
 use uuid::Uuid;
 use js_types::js_type::{JsType, JsVar, JsKey};
-use alloc::scope::Alloc;
+use alloc::Alloc;
 
 #[derive(Clone)]
 pub struct JsObjStruct {
     pub proto: JsProto,
     pub name: String,
-    pub dict: HashMap<JsKey, Alloc<JsVar>>,
+    pub dict: HashMap<JsKey, JsVar>,
 }
 
 impl JsObjStruct {
-    pub fn new(proto: JsProto, name: &str, kv_pairs: Vec<(JsKey, Alloc<JsVar>)>) -> JsObjStruct {
+    pub fn new(proto: JsProto, name: &str, kv_pairs: Vec<(JsKey, JsVar)>) -> JsObjStruct {
         JsObjStruct {
             proto: None,
             name: String::from(name),
@@ -22,12 +22,12 @@ impl JsObjStruct {
         }
     }
 
-    pub fn add_key(&mut self, k: JsKey, v: Alloc<JsVar>) {
+    pub fn add_key(&mut self, k: JsKey, v: JsVar) {
         self.dict.insert(k, v);
     }
 
     pub fn get_children(&self) -> HashSet<Uuid> {
-        self.dict.values().map(|v| v.borrow().uuid).collect()
+        self.dict.values().map(|v| v.uuid).collect()
     }
 }
 

--- a/src/js_types/js_type.rs
+++ b/src/js_types/js_type.rs
@@ -5,6 +5,8 @@ use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
+use alloc::Alloc;
+
 #[derive(Clone)]
 pub struct JsVar {
     pub binding: Option<String>,
@@ -44,6 +46,7 @@ impl Eq for JsVar {}
 
 #[derive(Clone)]
 pub enum JsPtrEnum {
+    JsNull,
     JsSym(String),
     JsStr(JsStrStruct),
     JsObj(JsObjStruct),
@@ -52,9 +55,8 @@ pub enum JsPtrEnum {
 #[derive(Clone)]
 pub enum JsType {
     JsUndef,
-    JsNull,
     JsNum(f64),
-    JsPtr(JsPtrEnum),
+    JsPtr,
 }
 
 #[derive(Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(associated_consts)]
 #![feature(drain)]
+#![feature(rc_would_unwrap)]
 
 extern crate uuid;
 extern crate typed_arena;
@@ -8,7 +9,7 @@ mod alloc;
 
 use std::collections::hash_set::HashSet;
 use std::ptr::null_mut;
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 use uuid::Uuid;
 
 use alloc::scope::Scope;
@@ -16,40 +17,47 @@ use js_types::js_type::JsVar;
 
 pub struct ScopeManager {
     root_scope: Rc<Scope>,
-    curr_scope: *mut Rc<Scope>,
+    //curr_scope: Weak<Scope>,
+    pub size: usize,
 }
 
-impl ScopeManager {
-    pub fn new<F>(callback: F) -> ScopeManager where F: Fn() -> HashSet<Uuid> + 'static {
-        let scope = Rc::new(Scope::new(callback));
+/*impl ScopeManager {
+    pub fn new<F>(callback: F) -> ScopeManager
+        where F: Fn() -> HashSet<Uuid> + 'static {
         let mut mgr =
             ScopeManager {
-                root_scope: scope,
-                curr_scope: null_mut(),
+                root_scope: Rc::new(Scope::new(callback)),
+                curr_scope: Rc::downgrade(&Rc::new(Scope::new(callback))),
+                size: 1,
             };
-        mgr.curr_scope = &mut (mgr.root_scope) as *mut Rc<Scope>;
+        mgr.curr_scope = Rc::downgrade(&mgr.root_scope.clone());
         mgr
     }
 
     pub fn push_scope<F>(&mut self, callback: F) where F: Fn() -> HashSet<Uuid> + 'static {
-        unsafe {
-            let weak_clone = Rc::downgrade(&*self.curr_scope.clone());
-            self.curr_scope =
-                Rc::get_mut(&mut *self.curr_scope)
-                    .unwrap()
-                    .add_child(Scope::as_child(weak_clone, callback)) as *mut Rc<Scope>;
-        }
+        let weak_clone = self.curr_scope.clone();
+        self.curr_scope =
+            // Is this possible?
+            if let Some(curr_scope) = self.curr_scope.upgrade() {
+                Rc::downgrade(Rc::get_mut(&mut curr_scope)
+                                .unwrap()
+                                .add_child(Scope::as_child(weak_clone, callback)))
+            } else {
+                panic!("Unable to upgrade curr_scope to Rc! Underlying data was destroyed!");
+            };
+        self.size += 1;
     }
 
     pub fn pop_scope(&mut self) {
-        let parent = unsafe { (*self.curr_scope).parent.clone() };
+        let parent = self.curr_scope.parent.clone();
         if let Some(parent) = parent {
             if let Some(mut scope) = parent.upgrade() {
                 // Pop old scope
                 let num_children = scope.children.len();
                 Rc::get_mut(&mut scope).unwrap().children.remove(num_children - 1);
                 // Set curr_scope to old scope's parent
-                self.curr_scope = &mut scope as *mut Rc<Scope>;
+                self.curr_scope = &mut scope;
+                self.size -= 1;
             }
         } else {
             panic!("Tried to pop to parent scope, but parent did not exist!");
@@ -57,15 +65,15 @@ impl ScopeManager {
     }
 
     pub fn alloc(&mut self, var: JsVar) -> Uuid {
-        unsafe { Rc::get_mut(&mut *self.curr_scope).unwrap().alloc(var) }
+        Rc::get_mut(self.curr_scope).unwrap().alloc(var)
     }
 
     pub fn load(&self, uuid: Uuid) -> Option<JsVar> {
-        unsafe { (*self.curr_scope).get_var_copy(&uuid) }
+        self.curr_scope.get_var_copy(&uuid)
     }
 
     pub fn store(&mut self, var: JsVar) -> bool {
-        unsafe { Rc::get_mut(&mut *self.curr_scope).unwrap().update_var(var) }
+        Rc::get_mut(self.curr_scope).unwrap().update_var(var)
     }
 }
 
@@ -74,3 +82,31 @@ pub fn init_gc<F>(callback: F) -> ScopeManager
     ScopeManager::new(callback)
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_set::HashSet;
+    use std::ptr::null_mut;
+    use std::rc::Rc;
+    use uuid::Uuid;
+
+    fn dummy_callback() -> HashSet<Uuid> {
+        HashSet::new()
+    }
+
+    #[test]
+    fn test_init_gc() {
+        let mgr = init_gc(dummy_callback);
+        //assert_eq!(mgr.size, 1);
+        //assert!(mgr.curr_scope != null_mut());
+        //assert!(mgr.root_scope.parent.is_none());
+        unsafe { assert!(Rc::would_unwrap(&*mgr.curr_scope)); }
+    }
+
+    #[test]
+    fn test_push_scope() {
+        let mut mgr = init_gc(dummy_callback);
+        mgr.push_scope(dummy_callback);
+    }
+}*/


### PR DESCRIPTION
Big changes on this branch:
- Scopes no longer own their allocations, this is handled by the new
  AllocBox struct
- Scopes no longer keep track of their children, since the scope tree is
  only ever walked upwards, while new scopes are added ad-hoc one at a
  time, and are popped from the tree when they exit.
- Allocations are no longer of type JsVar. Objects own their value
  types, except when they are pointers to other things. In this case,
  they own a JsVar containting a `JsPtr`, and they have to look up the
  JsVar's UUID in the AllocBox to figure out what it points to. As a
  consequence, allocations are only triggered when a new pointer-type
  object is allocated, so POD values are allocated per-stack frame, and
  aren't kept track of in the GC at all. JsNull is now a proper pointer
  type, too, since it never made sense that it wasn't.
- Most methods that took or returned a JsVar now take/return a JsPtrEnum
  instead, since those are the only values we care about in allocation.
